### PR TITLE
Fix auth if password contains special characters

### DIFF
--- a/open_door.py
+++ b/open_door.py
@@ -107,6 +107,7 @@ AUTH_HEADERS.update(COMMON_HEADERS)
 
 def auth(cache: bool, username: str, password: str) -> str:
     username = quote(username)
+    password = quote(password)
     auth_payload = f'grant_type=password&password={password}&username={username}'
 
     response = requests.request(


### PR DESCRIPTION
I use a generated password with special characters. This caused http error 500 (internal server error) during the auth operation. This PR fixes this by quoting the password properly.